### PR TITLE
support function returns

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,10 +1,11 @@
 import subprocess
 
-command = "npx erwin -d -fc 1 -pcf 1 -rcf 0 -bscf 2"
+command = "npx erwin -d -fc 1"
 
 while True:
   p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
   stdout, stderr = p.communicate()
   print(stdout.decode('utf-8'))
+  print(stderr.decode('utf-8'))
   if p.returncode != 0 or 'Error:' in stdout.decode('utf-8'):
     break

--- a/src/constraint.ts
+++ b/src/constraint.ts
@@ -812,31 +812,34 @@ export class DominanceDAG<T, Node extends DominanceNode<T>> {
             continue;
           }
           if (config.debug) {
-            let compatible_with_resolved_tails = true;
             for (let tail_info of this.node2tail.get(head)!) {
               assert(this.solutions.has(tail_info.tail_id),
                 `resolve: tail ${tail_info.tail_id} is not resolved`);
               if (tail_info.sub_dominance) {
                 if (!solution_to_head.issuperof(this.solutions.get(tail_info.tail_id)!)) {
-                  compatible_with_resolved_tails = false;
-                  break;
+                  assert(false,
+                    `resolve: the solution to head ${head}: ${solution_to_head.str()}
+                  is not the super of the solution to tail ${tail_info.tail_id}:
+                  ${this.solutions.get(tail_info.tail_id)!.str()}`);
                 }
               }
               else if (tail_info.super_dominance) {
                 if (!this.solutions.get(tail_info.tail_id)!.issuperof(solution_to_head)) {
-                  compatible_with_resolved_tails = false;
-                  break;
+                  assert(false,
+                    `resolve: the solution to head ${head}: ${solution_to_head.str()}
+                  is not the sub of the solution to tail ${tail_info.tail_id}:
+                  ${this.solutions.get(tail_info.tail_id)!.str()}`);
                 }
               }
               else {
                 if (!this.solutions.get(tail_info.tail_id)!.same(solution_to_head)) {
-                  compatible_with_resolved_tails = false;
-                  break;
+                  assert(false,
+                    `resolve: the solution to head ${head}: ${solution_to_head.str()}
+                  is not the same as the solution to tail ${tail_info.tail_id}:
+                  ${this.solutions.get(tail_info.tail_id)!.str()}`);
                 }
               }
             }
-            assert(compatible_with_resolved_tails,
-              `resolve: the solution to head is not compatible with the solutions to tails`);
           }
           // !Resolve the types of nonheads and nontails.
           this.solutions.set(head, solution_to_head);
@@ -964,31 +967,34 @@ export class DominanceDAG<T, Node extends DominanceNode<T>> {
           continue;
         }
         if (config.debug) {
-          let compatible_with_resolved_tails = true;
           for (let tail_info of this.node2tail.get(head)!) {
             assert(this.solutions.has(tail_info.tail_id),
               `resolve: tail ${tail_info.tail_id} is not resolved`);
             if (tail_info.sub_dominance) {
               if (!solution_to_head.issuperof(this.solutions.get(tail_info.tail_id)!)) {
-                compatible_with_resolved_tails = false;
-                break;
+                assert(false,
+                  `resolve: the solution to head ${head}: ${solution_to_head.str()}
+                is not the super of the solution to tail ${tail_info.tail_id}:
+                ${this.solutions.get(tail_info.tail_id)!.str()}`);
               }
             }
             else if (tail_info.super_dominance) {
               if (!this.solutions.get(tail_info.tail_id)!.issuperof(solution_to_head)) {
-                compatible_with_resolved_tails = false;
-                break;
+                assert(false,
+                  `resolve: the solution to head ${head}: ${solution_to_head.str()}
+                is not the sub of the solution to tail ${tail_info.tail_id}:
+                ${this.solutions.get(tail_info.tail_id)!.str()}`);
               }
             }
             else {
               if (!this.solutions.get(tail_info.tail_id)!.same(solution_to_head)) {
-                compatible_with_resolved_tails = false;
-                break;
+                assert(false,
+                  `resolve: the solution to head ${head}: ${solution_to_head.str()}
+                is not the same as the solution to tail ${tail_info.tail_id}:
+                ${this.solutions.get(tail_info.tail_id)!.str()}`);
               }
             }
           }
-          assert(compatible_with_resolved_tails,
-            `resolve: the solution to head is not compatible with the solutions to tails`);
         }
         // !Resolve the types of nonheads and nontails.
         this.solutions.set(head, solution_to_head);

--- a/src/type.ts
+++ b/src/type.ts
@@ -277,7 +277,7 @@ export class ElementaryType extends Type {
         ].filter(t => integer_types.some(tt => tt.same(t)));
       case "address":
         if (this.stateMutability === "payable") {
-          return [TypeProvider.address()];
+          return [TypeProvider.payable_address()];
         }
         else if (this.stateMutability === "nonpayable") {
           return [TypeProvider.payable_address(), TypeProvider.address()];
@@ -383,7 +383,7 @@ export class ElementaryType extends Type {
           return [TypeProvider.payable_address(), TypeProvider.address()];
         }
         else if (this.stateMutability === "nonpayable") {
-          return [TypeProvider.payable_address()];
+          return [TypeProvider.address()];
         }
         else {
           assert(false, `Elementary::sub_dominance: unrecognized stateMutability: ${this.stateMutability}`);
@@ -456,11 +456,11 @@ export class ElementaryType extends Type {
         return false;
       case "address":
         if (this.name !== "address") return false;
-        if (this.stateMutability === "payable") {
+        if (this.stateMutability === "nonpayable") {
           return true;
         }
-        else if (this.stateMutability === "nonpayable") {
-          if (et.stateMutability === "nonpayable") return true;
+        else if (this.stateMutability === "payable") {
+          if (et.stateMutability === "payable") return true;
           return false;
         }
       case "bool":
@@ -517,11 +517,11 @@ export class ElementaryType extends Type {
         return false;
       case "address":
         if (this.name !== "address") return false;
-        if (this.stateMutability === "payable") {
-          if (et.stateMutability === "payable") return true;
+        if (this.stateMutability === "nonpayable") {
+          if (et.stateMutability === "nonpayable") return true;
           return false;
         }
-        else if (this.stateMutability === "nonpayable") {
+        else if (this.stateMutability === "payable") {
           return true;
         }
       case "bool":
@@ -851,7 +851,8 @@ export const address_types : Type[] = [TypeProvider.address(), TypeProvider.paya
 export const elementary_types : Type[] = all_integer_types.concat(bool_types).concat(address_types);
 
 export const type_range_collection : Type[][] = [
-  all_integer_types,
+  integer_types,
+  uinteger_types,
   bool_types,
   address_types
 ];


### PR DESCRIPTION
Solidity supports such a function
```Solidity
function f() internal returns (uint256 a) {
    return a + 1;
}
```
In the type dominance DAG, the expression `a+1` super-dominates the vardecl `a`.
In this generation, Erwin has two strategies.
1) Erwin first generates the vardecl of `a` and then the corresponding expression.
The type range of the vardecl is `elementary_types`. The type range of the expression is decided during generation, but this generation process may narrow down the type range of `a` to an improper range. 
For instance, the expression can be `b >> a + b`. It's possible that the type range of `b` is `integer_types` and thus the type range of the whole expression is also `integer_types`. `b >> a` determines the type range of `a` is `uinteger_types`, resulting in a mismatch between the expression and that of `a`.
2) Erwin first generates the expression and then the vardecl.
Since we want to support the scenario where the identifier of the vardecl occurs at the both side of this vardeclstmt, we need to make sure the vardecl has been generated before the generation of the expression, which contradicts the applied generation order.

In summary, it's nontrivial to generate the code where the returned expression contains the identifier of the vardecl the expression corresponds to. Therefore, we disallow this pattern and will develop mutators to reach this program point.